### PR TITLE
Add basic prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,21 @@ files' symmetric key. Anyone who has access to this key can decrypt all files
 that have been encrypted by eldim. Try to keep this a secret, and do not
 transmit it insecurely.
 
+#### prometheusenabled
+The `prometheusenabled` is a boolean value. If it has the value `true`, it
+enabled exporting of Prometheus metrics. If it's `false` (default if missing),
+then Prometheus metrics export is disabled.
+
+#### prometheusauthuser
+The `prometheusauthuser` is a string that includes the HTTP Basic Auth Username
+for the Prometheus metrics endpoint (`/metrics`). It needs to be a-z, A-Z, 0-9,
+and 20-128 characters long, for security reasons.
+
+#### prometheusauthpass
+The `prometheusauthpass` is a string that contains the HTTP Basic Auth Password
+for the Prometheus metrics endpoint (`/metrics`). It needs to be a-z, A-Z, 0-9,
+and 20-128 characters long, for security reasons.
+
 #### swiftbackends
 The `swiftbackends` is an array, which contains a list of all backends that
 eldim will upload data to. More than one data storage is supported, but if you

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ The `path` label contains the URL of this HTTP Request, such as `/` or even
 The `status` label contains the HTTP Request Status Code that was returned,
 i.e. `200` or `400`.
 
+### Prometheus Metrics HTTP Basic Auth
+eldim exports `eldim_prometheus_metrics_scrape_auth`, which is a counter
+vector, and measures successful or unsuccessful scrapes of the Prometheus
+endpoint, based on their HTTP Basic Authentication Check. Through this you
+can monitor successful scrapes, scrape attempts without HTTP Basic Auth
+provided, as well as incorrect username or password attempts. It exposes
+the following labels:
+
+#### success
+Set to `true` or `false` depending on whether the scrape was successful.
+
+#### error
+Set to `HTTP-Basic-Auth-Not-Ok` during errors with HTTP Basic Auth, such as
+when no credentials were supplied, to `Incorrect-Username` when the username
+provided by the user is incorrect, or to `Incorrect-Password` when the password
+supplied is not correct.
+
 ### Default Prometheus for Go Metrics
 The Prometheus Client Library for Go exports a heap of metrics by default,
 which include, among others, Go Garbage Collection metrics, Goroutine Info,

--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ eldim exports `eldim_file_upload_request_time`, which is a histogram of the
 time it took to successfully serve a file upload request. The request time is
 measured in seconds, and the buckets are one for every minute, up to two hours.
 
+### Available Clients
+eldim exports `eldim_loaded_clients`, which is a gauge vector that contains
+how many clients are available and loaded from the configuration file to the
+system and have `ipv6` and `ipv4` addressess. This metric only changes when
+the configuration file is loaded, but can be useful to track historical changes
+in `eldim` hosts.
+eldim also exports `eldim_loaded_ip_addressess`, which is a gauge vector,
+containing information on how many IP addressess, and their version (`6`/`4`),
+have been loaded to `eldim`. Like above, this is only loaded when the
+`clients.yml` file is loaded, so it's also used for mostly historical reasons.
+
 ### Default Prometheus for Go Metrics
 The Prometheus Client Library for Go exports a heap of metrics by default,
 which include, among others, Go Garbage Collection metrics, Goroutine Info,

--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ containing information on how many IP addressess, and their version (`6`/`4`),
 have been loaded to `eldim`. Like above, this is only loaded when the
 `clients.yml` file is loaded, so it's also used for mostly historical reasons.
 
+### Uploaded Bytes
+eldim exports `eldim_files_uploaded_bytes_successful`, which is a gauge,
+whose value contains the total amount of bytes since eldim launch that have
+been successfully uploaded and processed by eldim. This includes the sum of
+the size of all files uploaded **to** eldim.
+In addition to that, there's also `eldim_files_uploaded_bytes_swift`, which
+includes the total amount of bytes that **eldim** uploaded, to OpenStack
+Swift backends. This number is different than the previous once since it
+includes encryption overhead, as well as the possibility of multiple OpenStack
+Swift backends, causing more data to be uploaded.
+
 ### Default Prometheus for Go Metrics
 The Prometheus Client Library for Go exports a heap of metrics by default,
 which include, among others, Go Garbage Collection metrics, Goroutine Info,

--- a/README.md
+++ b/README.md
@@ -97,6 +97,39 @@ it before it even reads the configuration file. They are:
 * `-j`: When set, it will output all logs in JSON format, instead of plaintext
 * `-c`: The path to the configuration file
 
+## Metrics
+As of `eldim v0.2.0`, eldim supports metrics exporting using Prometheus. In
+order to access the metrics, Prometheus has to be enabled from the
+configuration file. eldim **requires** HTTP Basic Authentication on the
+Metrics URL, and it is only available over HTTPS, through the same TCP port as
+the public API. For security reasons, both the username and password must be
+20-128 characters long.
+
+Currently the following metrics are exposed by `eldim`:
+
+### HTTP Requests Served
+eldim exports `eldim_http_requests_served`, which is a counter vector, with
+the following labels:
+
+#### method
+The `method` label contains the HTTP method that was used for this particular
+HTTP request, and common values can be `GET` and `POST`.
+
+#### path
+The `path` label contains the URL of this HTTP Request, such as `/` or even
+`/api/v1/file/upload/`.
+
+#### status
+The `status` label contains the HTTP Request Status Code that was returned,
+i.e. `200` or `400`.
+
+### Default Prometheus for Go Metrics
+The Prometheus Client Library for Go exports a heap of metrics by default,
+which include, among others, Go Garbage Collection metrics, Goroutine Info,
+Go compiler version, Application Memory Info, Running Threads, as well as
+Exporter Info, such as how many times the application data has been scraped
+by Prometheus.
+
 ## Configuration
 This section covers all the configuration options for eldim. There is a main
 configuration file which can control the behavior and settings of the server,

--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ when no credentials were supplied, to `Incorrect-Username` when the username
 provided by the user is incorrect, or to `Incorrect-Password` when the password
 supplied is not correct.
 
+### File Upload Error Metrics
+eldim exports `eldim_file_upload_errors_occured`, which is a counter vector,
+and essentially counts all errors occured during file upload requests. You
+can use this to see what errors come up, or if there is a spike in errors
+recently, an in coordination with `eldim_http_requests_served` identify
+problems in your eldim setup.
+
 ### Successful File Upload Time Histogram
 eldim exports `eldim_file_upload_request_time`, which is a histogram of the
 time it took to successfully serve a file upload request. The request time is

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ it before it even reads the configuration file. They are:
 * `-c`: The path to the configuration file
 
 ## Metrics
-As of `eldim v0.2.0`, eldim supports metrics exporting using Prometheus. In
+As of `eldim v0.2.0`, eldim supports metrics exporting using
+[Prometheus](https://prometheus.io/). In
 order to access the metrics, Prometheus has to be enabled from the
 configuration file. eldim **requires** HTTP Basic Authentication on the
 Metrics URL, and it is only available over HTTPS, through the same TCP port as

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ when no credentials were supplied, to `Incorrect-Username` when the username
 provided by the user is incorrect, or to `Incorrect-Password` when the password
 supplied is not correct.
 
+### Successful File Upload Time Histogram
+eldim exports `eldim_file_upload_request_time`, which is a histogram of the
+time it took to successfully serve a file upload request. The request time is
+measured in seconds, and the buckets are one for every minute, up to two hours.
+
 ### Default Prometheus for Go Metrics
 The Prometheus Client Library for Go exports a heap of metrics by default,
 which include, among others, Go Garbage Collection metrics, Goroutine Info,

--- a/ds.go
+++ b/ds.go
@@ -24,6 +24,11 @@ type config struct {
 
 	/* Encryption */
 	EncryptionKey string `yaml:"encryptionkey"`
+
+	/* Prometheus Metrics */
+	PrometheusEnabled  bool   `yaml:"prometheusenabled"`
+	PrometheusAuthUser string `yaml:"prometheusauthuser"`
+	PrometheusAuthPass string `yaml:"prometheusauthpass"`
 }
 
 /*

--- a/eldim.yml
+++ b/eldim.yml
@@ -43,6 +43,19 @@ tempuploadpath: "/var/lib/eldim"
 encryptionkey: "Insecure"
 
 #####
+# Prometheus
+#####
+
+# Enable or disable Prometheus metrics
+prometheusenabled: true
+
+# Prometheus Endpoint (/metrics) HTTP Basic Auth Username
+prometheusauthuser: "username"
+
+# Prometheus Endpoint (/metrics) HTTP Basic Auth Password
+prometheusauthpass: "password"
+
+#####
 # Backends
 #####
 

--- a/http.go
+++ b/http.go
@@ -257,6 +257,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	}
 
 	logrus.Printf("%s: File loaded into RAM. Size: %d bytes.", rid, len(upFile))
+	promBytesUploadedSuc.Add(float64(len(upFile)))
 	logrus.Printf("%s: Encrypting file...", rid)
 
 	/* Create a new TripleSec Cipher, with a nil salt (required) */
@@ -304,6 +305,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 			promFileUpErrors.With(p.Labels{"error": "OpenStack-Swift-Upload-Failed"}).Inc()
 		} else {
 			uploads++
+			promBytesUploadedOSS.Add(float64(len(encFile)))
 		}
 
 		/* Set the expiry header */

--- a/http.go
+++ b/http.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/daknob/hlog"
 	p "github.com/prometheus/client_golang/prometheus"
@@ -53,6 +54,9 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	if conf.ServerTokens {
 		w.Header().Set("Server", fmt.Sprintf("eldim %s", version))
 	}
+
+	/* Start Request Service Timer */
+	now := time.Now().Unix()
 
 	/* Get IP Address of Request */
 	ipAddr, _, err := net.SplitHostPort(r.RemoteAddr)
@@ -314,6 +318,9 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "text/plain")
 	fmt.Fprintf(w, "Ok")
+
+	/* Update Prometheus on the successful request handling */
 	promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "200"}).Inc()
+	promReqServTimeHist.Observe(float64(time.Now().Unix() - now))
 
 }

--- a/http.go
+++ b/http.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/daknob/hlog"
+	p "github.com/prometheus/client_golang/prometheus"
 
 	"github.com/keybase/go-triplesec"
 
@@ -40,6 +41,7 @@ func index(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		fmt.Fprintf(w, " ")
 	}
 
+	promReqServed.With(p.Labels{"method": "GET", "path": "/", "status": "200"}).Inc()
 }
 
 /*
@@ -65,6 +67,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusForbidden)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "IP Address not in access list")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "403"}).Inc()
 		return
 	}
 	logrus.Printf("%s: Detected Hostname: %s", rid, hostname)
@@ -81,6 +84,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Error while processing upload request")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 	logrus.Printf("%s: Done parsing upload", rid)
@@ -91,6 +95,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusBadRequest)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "File name not supplied")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "400"}).Inc()
 		return
 	}
 
@@ -130,6 +135,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "An error occured while processing the uploaded file")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 	logrus.Printf("%s: Connection successful. %d OpenStack Swift Backends live.", rid, len(sc))
@@ -143,6 +149,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 			w.WriteHeader(http.StatusBadRequest)
 			w.Header().Set("Content-Type", "text/plain")
 			fmt.Fprintf(w, "File already exists.")
+			promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "400"}).Inc()
 			return
 		}
 	}
@@ -159,6 +166,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusBadRequest)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Did not supply a valid file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "400"}).Inc()
 		return
 	}
 
@@ -172,6 +180,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to save file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 
@@ -181,6 +190,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to save file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 
@@ -190,6 +200,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to save file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 	err = nfile.Close()
@@ -198,6 +209,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to save file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 
@@ -212,6 +224,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to save file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 
@@ -222,6 +235,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to save file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 
@@ -235,6 +249,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to encrypt file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 
@@ -245,6 +260,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to encrypt file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 		return
 	}
 
@@ -290,6 +306,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Failed to store file.")
+		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "500"}).Inc()
 	}
 
 	/* All good, finally it's over */
@@ -297,5 +314,6 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "text/plain")
 	fmt.Fprintf(w, "Ok")
+	promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "200"}).Inc()
 
 }

--- a/main.go
+++ b/main.go
@@ -44,6 +44,13 @@ var (
 			"error",
 		},
 	)
+	promReqServTimeHist = p.NewHistogram(
+		p.HistogramOpts{
+			Name:    "eldim_file_upload_request_time",
+			Help:    "Histogram of time of successful file uploads to eldim",
+			Buckets: p.LinearBuckets(0, 60, 120),
+		},
+	)
 )
 
 const (
@@ -111,6 +118,7 @@ func main() {
 	/* Initialize Prometheus */
 	p.MustRegister(promReqServed)
 	p.MustRegister(promMetricsAuth)
+	p.MustRegister(promReqServTimeHist)
 
 	/* Various web server configurations */
 	logrus.Printf("Configuring the HTTP Server...")

--- a/main.go
+++ b/main.go
@@ -44,6 +44,15 @@ var (
 			"error",
 		},
 	)
+	promFileUpErrors = p.NewCounterVec(
+		p.CounterOpts{
+			Name: "eldim_file_upload_errors_occured",
+			Help: "Types of errors occured during file uploads",
+		},
+		[]string{
+			"error",
+		},
+	)
 	promReqServTimeHist = p.NewHistogram(
 		p.HistogramOpts{
 			Name:    "eldim_file_upload_request_time",
@@ -118,6 +127,7 @@ func main() {
 	/* Initialize Prometheus */
 	p.MustRegister(promReqServed)
 	p.MustRegister(promMetricsAuth)
+	p.MustRegister(promFileUpErrors)
 	p.MustRegister(promReqServTimeHist)
 
 	/* Various web server configurations */

--- a/main.go
+++ b/main.go
@@ -60,6 +60,24 @@ var (
 			Buckets: p.LinearBuckets(0, 60, 120),
 		},
 	)
+	promClients = p.NewGaugeVec(
+		p.GaugeOpts{
+			Name: "eldim_loaded_clients",
+			Help: "Clients that are allowed to upload files to eldim",
+		},
+		[]string{
+			"type",
+		},
+	)
+	promIPs = p.NewGaugeVec(
+		p.GaugeOpts{
+			Name: "eldim_loaded_ip_addressess",
+			Help: "IP Addressess that are allowed to upload files to eldim",
+		},
+		[]string{
+			"version",
+		},
+	)
 )
 
 const (
@@ -129,6 +147,28 @@ func main() {
 	p.MustRegister(promMetricsAuth)
 	p.MustRegister(promFileUpErrors)
 	p.MustRegister(promReqServTimeHist)
+	p.MustRegister(promClients)
+	p.MustRegister(promIPs)
+
+	/* Set Prometheus Loaded Clients Metric */
+	var v4 float64
+	var v6 float64
+	var v4a float64
+	var v6a float64
+	for _, c := range clients {
+		if len(c.Ipv4) >= 1 {
+			v4++
+			v4a += float64(len(c.Ipv4))
+		}
+		if len(c.Ipv6) >= 1 {
+			v6++
+			v6a += float64(len(c.Ipv6))
+		}
+	}
+	promClients.With(p.Labels{"type": "ipv6"}).Set(v6)
+	promClients.With(p.Labels{"type": "ipv4"}).Set(v4)
+	promIPs.With(p.Labels{"version": "6"}).Set(v6a)
+	promIPs.With(p.Labels{"version": "4"}).Set(v4a)
 
 	/* Various web server configurations */
 	logrus.Printf("Configuring the HTTP Server...")

--- a/main.go
+++ b/main.go
@@ -34,6 +34,16 @@ var (
 			"status",
 		},
 	)
+	promMetricsAuth = p.NewCounterVec(
+		p.CounterOpts{
+			Name: "eldim_prometheus_metrics_scrape_auth",
+			Help: "HTTP Requests to the Prometheus Metrics Endpoint and their Authentication Status",
+		},
+		[]string{
+			"success",
+			"error",
+		},
+	)
 )
 
 const (
@@ -100,6 +110,7 @@ func main() {
 
 	/* Initialize Prometheus */
 	p.MustRegister(promReqServed)
+	p.MustRegister(promMetricsAuth)
 
 	/* Various web server configurations */
 	logrus.Printf("Configuring the HTTP Server...")
@@ -114,6 +125,7 @@ func main() {
 			conf.PrometheusAuthUser,
 			conf.PrometheusAuthPass,
 			"Prometheus Metrics",
+			*promMetricsAuth,
 			httpHandlerToHTTPRouterHandler(
 				promhttp.Handler(),
 			),

--- a/main.go
+++ b/main.go
@@ -137,18 +137,22 @@ func main() {
 	router := httprouter.New()
 	router.GET("/", index)
 	router.POST("/api/v1/file/upload/", v1fileUpload)
-	router.GET(
-		"/metrics",
-		requestBasicAuth(
-			conf.PrometheusAuthUser,
-			conf.PrometheusAuthPass,
-			"Prometheus Metrics",
-			*promMetricsAuth,
-			httpHandlerToHTTPRouterHandler(
-				promhttp.Handler(),
+
+	/* Only enable Prometheus metrics if configured */
+	if conf.PrometheusEnabled {
+		router.GET(
+			"/metrics",
+			requestBasicAuth(
+				conf.PrometheusAuthUser,
+				conf.PrometheusAuthPass,
+				"Prometheus Metrics",
+				*promMetricsAuth,
+				httpHandlerToHTTPRouterHandler(
+					promhttp.Handler(),
+				),
 			),
-		),
-	)
+		)
+	}
 
 	/* Configure TLS */
 	tlsConfig := &tls.Config{

--- a/main.go
+++ b/main.go
@@ -78,6 +78,18 @@ var (
 			"version",
 		},
 	)
+	promBytesUploadedSuc = p.NewCounter(
+		p.CounterOpts{
+			Name: "eldim_files_uploaded_bytes_successful",
+			Help: "Amount of bytes of files uploaded to eldim successfully",
+		},
+	)
+	promBytesUploadedOSS = p.NewCounter(
+		p.CounterOpts{
+			Name: "eldim_files_uploaded_bytes_swift",
+			Help: "Amount of bytes of files uploaded from eldim to OpenStack Swift Backends",
+		},
+	)
 )
 
 const (
@@ -149,6 +161,8 @@ func main() {
 	p.MustRegister(promReqServTimeHist)
 	p.MustRegister(promClients)
 	p.MustRegister(promIPs)
+	p.MustRegister(promBytesUploadedSuc)
+	p.MustRegister(promBytesUploadedOSS)
 
 	/* Set Prometheus Loaded Clients Metric */
 	var v4 float64

--- a/util.go
+++ b/util.go
@@ -66,3 +66,13 @@ func requestBasicAuth(username, password, realm string, handler httprouter.Handl
 		handler(w, r, Params)
 	}
 }
+
+/*
+httpHandlerToHTTPRouterHandler is a function that converts an HTTP Handler to an HTTPRouter Handler, ignoring
+the Params field and assuming it is not used
+*/
+func httpHandlerToHTTPRouterHandler(h http.Handler) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		h.ServeHTTP(w, r)
+	}
+}

--- a/util.go
+++ b/util.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"fmt"
+	"net/http"
 )
 
 /*
@@ -23,4 +26,41 @@ func getIPName(ip string) (string, error) {
 	}
 
 	return "", fmt.Errorf("IP Address not a client")
+}
+
+/*
+requestBasicAuth is an HTTP Handler wrapper that will require the passed handler to
+be served only if the HTTP Basic Authentication Credentials are correct.
+*/
+func requestBasicAuth(username, password, realm string, handler http.HandlerFunc) http.HandlerFunc {
+
+	/* Calculate the SHA-256 Hash of the Required Username and Password */
+	RequiredUserNameHash := sha256.Sum256([]byte(username))
+	RequiredPasswordHash := sha256.Sum256([]byte(password))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		user, pass, ok := r.BasicAuth()
+
+		/* Calculate the SHA-256 Hash of the Given Username and Password */
+		PassedUsername := sha256.Sum256([]byte(user))
+		PassedPassword := sha256.Sum256([]byte(pass))
+
+		/*
+			subtle.ConstantTimeCompare is used so the username and password comparison take constant time,
+			and therefore do not leak information about the length of the password, or allow time-based side
+			channel attacks. However, in order to prevent password length guessing, SHA-256 is used, which is
+			always a constant size. Calculation of the SHA-256 hash can still be attacked, but isn't as likely,
+			since the inputs are constants.
+		*/
+
+		if !ok || subtle.ConstantTimeCompare(PassedUsername[:], RequiredUserNameHash[:]) != 1 || subtle.ConstantTimeCompare(PassedPassword[:], RequiredPasswordHash[:]) != 1 {
+			w.Header().Set("WWW-Authenticate", `Basic realm="`+realm+`"`)
+			w.WriteHeader(401)
+			w.Write([]byte("You need to supply the correct credentials for this page.\n"))
+			return
+		}
+
+		handler(w, r)
+	}
 }

--- a/util.go
+++ b/util.go
@@ -5,6 +5,8 @@ import (
 	"crypto/subtle"
 	"fmt"
 	"net/http"
+
+	"github.com/julienschmidt/httprouter"
 )
 
 /*
@@ -32,13 +34,13 @@ func getIPName(ip string) (string, error) {
 requestBasicAuth is an HTTP Handler wrapper that will require the passed handler to
 be served only if the HTTP Basic Authentication Credentials are correct.
 */
-func requestBasicAuth(username, password, realm string, handler http.HandlerFunc) http.HandlerFunc {
+func requestBasicAuth(username, password, realm string, handler httprouter.Handle) httprouter.Handle {
 
 	/* Calculate the SHA-256 Hash of the Required Username and Password */
 	RequiredUserNameHash := sha256.Sum256([]byte(username))
 	RequiredPasswordHash := sha256.Sum256([]byte(password))
 
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request, Params httprouter.Params) {
 
 		user, pass, ok := r.BasicAuth()
 
@@ -61,6 +63,6 @@ func requestBasicAuth(username, password, realm string, handler http.HandlerFunc
 			return
 		}
 
-		handler(w, r)
+		handler(w, r, Params)
 	}
 }

--- a/validator.go
+++ b/validator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 
 	"github.com/ncw/swift"
 	yaml "gopkg.in/yaml.v2"
@@ -146,6 +147,23 @@ func validateConfig(conf config) error {
 	}
 	if len(conf.EncryptionKey) < 30 {
 		logrus.Warnf("The encryption key set is less than 30 characters. It may not be so secure")
+	}
+
+	/* Validate Prometheus Settings */
+	if conf.PrometheusEnabled == true {
+		/* Only check Prometheus Configuration if Prometheus is enabled */
+		if conf.PrometheusAuthUser == "" {
+			return fmt.Errorf("You need to set the prometheusauthuser in the configuration file. eldim only works with HTTP Basic Auth for Prometheus Metrics")
+		}
+		if !regexp.MustCompile("^[a-zA-Z0-9]{20,128}$").MatchString(conf.PrometheusAuthUser) {
+			return fmt.Errorf("The prometheusauthuser must contain a-z, A-Z, and 0-9, and must be 20-128 characters long")
+		}
+		if conf.PrometheusAuthPass == "" {
+			return fmt.Errorf("You need to set the prometheusauthpass in the configuration file. eldim only works with HTTP Basic Auth for Prometheus Metrics")
+		}
+		if !regexp.MustCompile("^[a-zA-Z0-9]{20,128}$").MatchString(conf.PrometheusAuthPass) {
+			return fmt.Errorf("The prometheusauthpass must contain a-z, A-Z, and 0-9, and must be 20-128 characters long")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds Prometheus support and export capabilities to `eldim`, along with a series of metrics that may be useful. The metrics and configuration are included in the `README.md`.