### PR TITLE
Address breaking API changes in TripleSec

### DIFF
--- a/cmd/decrypt/main.go
+++ b/cmd/decrypt/main.go
@@ -44,7 +44,12 @@ func main() {
 
 	logrus.Printf("Decrypting data...")
 
-	/* Create a new TripleSec cipher */
+	/*
+	   Create a new TripleSec cipher
+
+	   The number 4 being passed is the Cipher version, which is
+	   currently the latest version supported by TripleSec.
+	*/
 	cipher, err := triplesec.NewCipher([]byte(*encryptionKey), nil, 4)
 	if err != nil {
 		logrus.Fatalf("Failed to initialize the cryptographic engine: %v", err)

--- a/cmd/decrypt/main.go
+++ b/cmd/decrypt/main.go
@@ -45,7 +45,7 @@ func main() {
 	logrus.Printf("Decrypting data...")
 
 	/* Create a new TripleSec cipher */
-	cipher, err := triplesec.NewCipher([]byte(*encryptionKey), nil)
+	cipher, err := triplesec.NewCipher([]byte(*encryptionKey), nil, 4)
 	if err != nil {
 		logrus.Fatalf("Failed to initialize the cryptographic engine: %v", err)
 	}

--- a/http.go
+++ b/http.go
@@ -260,7 +260,12 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	promBytesUploadedSuc.Add(float64(len(upFile)))
 	logrus.Printf("%s: Encrypting file...", rid)
 
-	/* Create a new TripleSec Cipher, with a nil salt (required) */
+	/*
+	   Create a new TripleSec Cipher, with a nil salt (required)
+
+	   The number 4 being passed is the Cipher version, with 4 being
+	   currently the latest version according to the documentation.
+	*/
 	enc, err := triplesec.NewCipher([]byte(conf.EncryptionKey), nil, 4)
 	if err != nil {
 		logrus.Errorf("%s: Failed to initialize the encryption algorithm: %v", rid, err)

--- a/http.go
+++ b/http.go
@@ -261,7 +261,7 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	logrus.Printf("%s: Encrypting file...", rid)
 
 	/* Create a new TripleSec Cipher, with a nil salt (required) */
-	enc, err := triplesec.NewCipher([]byte(conf.EncryptionKey), nil)
+	enc, err := triplesec.NewCipher([]byte(conf.EncryptionKey), nil, 4)
 	if err != nil {
 		logrus.Errorf("%s: Failed to initialize the encryption algorithm: %v", rid, err)
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
The library `eldim` depends on for file encryption, TripleSec, has changed its API and has introduced breaking changes that prevent the project from building.

The different that is currently affecting this codebase is a new parameter that is required on new cipher creation with `NewCipher`. This function now requires a `version` of type `Version` to work.

The `eldim` service and the decryption CLI have been updated to pass this version to the function.