### PR TITLE
Add ability to identify clients by password

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ host. The shortest format must be used, so `2001:db8::1` will work, but
 #### password
 The `password` string is a password that can be supplied by the `password` POST
 form element that can be used to lookup clients instead of by their IP Address.
-The `password` is checked before the IP Address of the host.
+The `password` is checked before the IP Address of the host. For security
+reasons, the field *must* be above 32 characters long.
 
 ### Example Configuration Files
 There are example configuration files that include all of the above commands
@@ -380,7 +381,7 @@ Any other HTTP Status Code or message is an error.
 This `POST` parameter is a string that specifies a password, which will be
 checked against `eldim`'s `clients.yml` and will identify hosts based on their
 password key, instead of their IP Address. Password checks take precedence over
-IP Address checks. The password must be between 20 and 128 characters for
+IP Address checks. The password must be between 32 and 128 characters for
 security reasons.
 
 ## How to upload data from a server

--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ The `ipv6` array is a list of strings with IPv6 addresses that belong to this
 host. The shortest format must be used, so `2001:db8::1` will work, but
 `2001:0db8:0000:0000:0000:0000:0000:0001` will not. They can be more than one.
 
+#### password
+The `password` string is a password that can be supplied by the `password` POST
+form element that can be used to lookup clients instead of by their IP Address.
+The `password` is checked before the IP Address of the host.
+
 ### Example Configuration Files
 There are example configuration files that include all of the above commands
 in this repository. Feel free to start with them as your base, and then make
@@ -359,6 +364,13 @@ to be uploaded here.
 
 This API call will return `HTTP 200` and print `Ok` if the upload succeeded.
 Any other HTTP Status Code or message is an error.
+
+#### password
+This `POST` parameter is a string that specifies a password, which will be
+checked against `eldim`'s `clients.yml` and will identify hosts based on their
+password key, instead of their IP Address. Password checks take precedence over
+IP Address checks. The password must be between 20 and 128 characters for
+security reasons.
 
 ## How to upload data from a server
 You can basically upload files to eldim in any way you like, as long as you

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ host. The shortest format must be used, so `2001:db8::1` will work, but
 The `password` string is a password that can be supplied by the `password` POST
 form element that can be used to lookup clients instead of by their IP Address.
 The `password` is checked before the IP Address of the host. For security
-reasons, the field **must** be above 32 characters long.
+reasons, the field **must** be between 32 and 128 characters in size.
 
 ### Example Configuration Files
 There are example configuration files that include all of the above commands

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ eldim exports `eldim_loaded_clients`, which is a gauge vector that contains
 how many clients are available and loaded from the configuration file to the
 system and have `ipv6` and `ipv4` addressess. This metric only changes when
 the configuration file is loaded, but can be useful to track historical changes
-in `eldim` hosts.
+in `eldim` hosts. This field may also contain `password` for clients that are
+being identified by a password.
 eldim also exports `eldim_loaded_ip_addressess`, which is a gauge vector,
 containing information on how many IP addressess, and their version (`6`/`4`),
 have been loaded to `eldim`. Like above, this is only loaded when the

--- a/README.md
+++ b/README.md
@@ -175,6 +175,17 @@ Swift backends. This number is different than the previous once since it
 includes encryption overhead, as well as the possibility of multiple OpenStack
 Swift backends, causing more data to be uploaded.
 
+### Client Identification Type
+eldim exports `eldim_client_id_type`, which is a counter vector, with the
+following label:
+
+#### type
+The `type` label contains the type of each successful authentication done
+against `eldim`. It contains two possible values: `ipaddr` and `password`. The
+first value is assigned every time a successful authentication is performed
+with an IP Address, and the second is assigned every time a successful
+authentication is performed with a password.
+
 ### Default Prometheus for Go Metrics
 The Prometheus Client Library for Go exports a heap of metrics by default,
 which include, among others, Go Garbage Collection metrics, Goroutine Info,

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ host. The shortest format must be used, so `2001:db8::1` will work, but
 The `password` string is a password that can be supplied by the `password` POST
 form element that can be used to lookup clients instead of by their IP Address.
 The `password` is checked before the IP Address of the host. For security
-reasons, the field *must* be above 32 characters long.
+reasons, the field **must** be above 32 characters long.
 
 ### Example Configuration Files
 There are example configuration files that include all of the above commands

--- a/clients.yml
+++ b/clients.yml
@@ -19,3 +19,6 @@
     - "127.0.0.1"
   ipv6:
     - "::1"
+-
+  name: "password-match"
+  password: "this-is-a-very-secure-password"

--- a/ds.go
+++ b/ds.go
@@ -50,7 +50,8 @@ clientInfo is the data structure containing all information about
 a client that can connect to the eldim service
 */
 type clientInfo struct {
-	Name string   `yaml:"name"`
-	Ipv4 []string `yaml:"ipv4"`
-	Ipv6 []string `yaml:"ipv6"`
+	Name     string   `yaml:"name"`
+	Ipv4     []string `yaml:"ipv4"`
+	Ipv6     []string `yaml:"ipv6"`
+	Password string   `yaml:"password"`
 }

--- a/http.go
+++ b/http.go
@@ -86,6 +86,10 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 			promFileUpErrors.With(p.Labels{"error": "IP-Not-Allowed"}).Inc()
 			return
 		}
+
+		promClientIDs.With(p.Labels{"type": "ipaddr"}).Inc()
+	} else {
+		promClientIDs.With(p.Labels{"type": "password"}).Inc()
 	}
 
 	logrus.Printf("%s: Detected Hostname: %s", rid, hostname)

--- a/http.go
+++ b/http.go
@@ -64,17 +64,30 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		logrus.Errorf("%s: Failed to parse Remote IP of request: %v", rid, err)
 	}
 
-	/* Check if the IP Address is a known and allowed client */
-	hostname, err := getIPName(ipAddr)
+	/* Check if the Password supplied is allowed and matches a host */
+	hostname, err := getPassName(r.PostFormValue("password"))
 	if err != nil {
-		logrus.Printf("%s: IP Address %s is not a known client", rid, ipAddr)
-		w.WriteHeader(http.StatusForbidden)
-		w.Header().Set("Content-Type", "text/plain")
-		fmt.Fprintf(w, "IP Address not in access list")
-		promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "403"}).Inc()
-		promFileUpErrors.With(p.Labels{"error": "IP-Not-Allowed"}).Inc()
-		return
+		/*
+			This is the case in which the password that was supplied by
+			the user did not match any of the passwords in the database.
+
+			This means we need to do an IP-based check, and try and see
+			if this IP Address is allowed as a client.
+		*/
+		logrus.Printf("%s: Client at %s did not supply a known password. Checking by IP", rid, ipAddr)
+
+		hostname, err = getIPName(ipAddr)
+		if err != nil {
+			logrus.Printf("%s: IP Address %s is not a known client", rid, ipAddr)
+			w.WriteHeader(http.StatusForbidden)
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "IP Address not in access list")
+			promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "403"}).Inc()
+			promFileUpErrors.With(p.Labels{"error": "IP-Not-Allowed"}).Inc()
+			return
+		}
 	}
+
 	logrus.Printf("%s: Detected Hostname: %s", rid, hostname)
 
 	/* Begin file processing */

--- a/main.go
+++ b/main.go
@@ -90,6 +90,15 @@ var (
 			Help: "Amount of bytes of files uploaded from eldim to OpenStack Swift Backends",
 		},
 	)
+	promClientIDs = p.NewCounterVec(
+		p.CounterOpts{
+			Name: "eldim_client_id_type",
+			Help: "Type of Client Identification used (Password vs IP Address)",
+		},
+		[]string{
+			"type",
+		},
+	)
 )
 
 const (
@@ -163,6 +172,7 @@ func main() {
 	p.MustRegister(promIPs)
 	p.MustRegister(promBytesUploadedSuc)
 	p.MustRegister(promBytesUploadedOSS)
+	p.MustRegister(promClientIDs)
 
 	/* Set Prometheus Loaded Clients Metric */
 	var v4 float64

--- a/main.go
+++ b/main.go
@@ -177,6 +177,7 @@ func main() {
 	/* Set Prometheus Loaded Clients Metric */
 	var v4 float64
 	var v6 float64
+	var pass float64
 	var v4a float64
 	var v6a float64
 	for _, c := range clients {
@@ -188,9 +189,13 @@ func main() {
 			v6++
 			v6a += float64(len(c.Ipv6))
 		}
+		if c.Password != "" {
+			pass++
+		}
 	}
 	promClients.With(p.Labels{"type": "ipv6"}).Set(v6)
 	promClients.With(p.Labels{"type": "ipv4"}).Set(v4)
+	promClients.With(p.Labels{"type": "password"}).Set(pass)
 	promIPs.With(p.Labels{"version": "6"}).Set(v6a)
 	promIPs.With(p.Labels{"version": "4"}).Set(v4a)
 

--- a/util.go
+++ b/util.go
@@ -32,6 +32,25 @@ func getIPName(ip string) (string, error) {
 }
 
 /*
+getPassName returns the client name for a given Password password. If it is not
+found, an error is returned.
+*/
+func getPassName(password string) (string, error) {
+
+	if password == "" {
+		return "", fmt.Errorf("Password was empty. Did not match")
+	}
+
+	for _, c := range clients {
+		if c.Password == password {
+			return c.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("Password did not match client database")
+}
+
+/*
 requestBasicAuth is an HTTP Handler wrapper that will require the passed handler to
 be served only if the HTTP Basic Authentication Credentials are correct.
 */


### PR DESCRIPTION
This Pull Request aims to add the ability to `eldim` to be able to identify clients using passwords (keys) and not solely based on their IP Address.

This will address cases of dynamic IP Address changes, such as on a laptop or mobile phone, and will also address NAT issues on IPv4 where multiple devices may use the same IP Address to reach the `eldim` server.

This key / password *MUST* be unique per host, and for security reasons it is between 20-128 characters long.