### PR TITLE
Fix Prometheus Metric Counter Initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,11 +175,11 @@ func main() {
 	p.MustRegister(promClientIDs)
 
 	/* Set Prometheus Loaded Clients Metric */
-	var v4 float64
-	var v6 float64
-	var pass float64
-	var v4a float64
-	var v6a float64
+	var v4 float64 = 0
+	var v6 float64 = 0
+	var pass float64 = 0
+	var v4a float64 = 0
+	var v6a float64 = 0
 	for _, c := range clients {
 		if len(c.Ipv4) >= 1 {
 			v4++


### PR DESCRIPTION
Five variables of type `float64` that have been used for Prometheus metrics were incremented (`++`) without first being initialized.

In Go, this is okay, as all numeric variables are initialized to 0. However, it is preferable to explicitly zero them out upon declaration, to ensure consistent behavior, even in the case Go decides to change this in the future.