### PR TITLE
Add Prometheus metric for successful auths/uploads per host

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,23 @@ first value is assigned every time a successful authentication is performed
 with an IP Address, and the second is assigned every time a successful
 authentication is performed with a password.
 
+### Successful Authentications by Host Name
+eldim exports `eldim_host_authentications`, which is a counter vector, counting
+how many successful authentication attempts have happened so far, with the
+following label:
+
+#### hostname
+The `hostname` label contains the host name that has performed the
+authentication successfully.
+
+### Successful File Uploads by Host Name
+eldim exports `eldim_host_uploads`, which is a counter vector, counting how
+many successful file uploads have happened so far, with the following label:
+
+#### hostname
+The `hostname` label contains the host name that has performed the successful
+file upload.
+
 ### Default Prometheus for Go Metrics
 The Prometheus Client Library for Go exports a heap of metrics by default,
 which include, among others, Go Garbage Collection metrics, Goroutine Info,

--- a/http.go
+++ b/http.go
@@ -92,7 +92,9 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 		promClientIDs.With(p.Labels{"type": "password"}).Inc()
 	}
 
+	/* Authentication has happened successfully */
 	logrus.Printf("%s: Detected Hostname: %s", rid, hostname)
+	promHostAuths.With(p.Labels{"hostname": hostname}).Inc()
 
 	/* Begin file processing */
 	logrus.Printf("%s: Parsing upload from %s [%s]", rid, hostname, ipAddr)
@@ -364,5 +366,6 @@ func v1fileUpload(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 	/* Update Prometheus on the successful request handling */
 	promReqServed.With(p.Labels{"method": "POST", "path": "/api/v1/file/upload/", "status": "200"}).Inc()
 	promReqServTimeHist.Observe(float64(time.Now().Unix() - now))
+	promHostUploads.With(p.Labels{"hostname": hostname}).Inc()
 
 }

--- a/main.go
+++ b/main.go
@@ -99,6 +99,24 @@ var (
 			"type",
 		},
 	)
+	promHostAuths = p.NewCounterVec(
+		p.CounterOpts{
+			Name: "eldim_host_authentications",
+			Help: "Successful authentications to eldim by hostname",
+		},
+		[]string{
+			"hostname",
+		},
+	)
+	promHostUploads = p.NewCounterVec(
+		p.CounterOpts{
+			Name: "eldim_host_uploads",
+			Help: "Successful file uploads to eldim by hostname",
+		},
+		[]string{
+			"hostname",
+		},
+	)
 )
 
 const (
@@ -173,6 +191,8 @@ func main() {
 	p.MustRegister(promBytesUploadedSuc)
 	p.MustRegister(promBytesUploadedOSS)
 	p.MustRegister(promClientIDs)
+	p.MustRegister(promHostAuths)
+	p.MustRegister(promHostUploads)
 
 	/* Set Prometheus Loaded Clients Metric */
 	var v4 float64 = 0


### PR DESCRIPTION
This Pull Request aims to add two new Prometheus metrics:

- The amount of successful authentication attempts to `eldim` per host
- The amount of successful file uploads to `eldim` per host

This gives visibility into which hosts are using `eldim` and at which time, as well as which hosts have trouble uploading files to `eldim`, by tracking the difference of the two metrics.